### PR TITLE
Payload and device token validations

### DIFF
--- a/payload/aps.go
+++ b/payload/aps.go
@@ -1,4 +1,3 @@
-// Package payload serializes a JSON payload to push.
 package payload
 
 import (
@@ -87,4 +86,17 @@ func (a *APS) Map() map[string]interface{} {
 // MarshalJSON allows you to json.Marshal(aps) directly.
 func (a APS) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.Map())
+}
+
+// Validate APS payload.
+func (a *APS) Validate() error {
+	if a == nil {
+		return ErrIncomplete
+	}
+
+	// must have a body or a badge (or custom data)
+	if len(a.Alert.Body) == 0 && a.Badge == badge.Preserve {
+		return ErrIncomplete
+	}
+	return nil
 }

--- a/payload/aps_test.go
+++ b/payload/aps_test.go
@@ -53,3 +53,31 @@ func TestCustomArray(t *testing.T) {
 	expected := []byte(`{"acme2":["bang","whiz"],"aps":{"alert":"Message received from Bob"}}`)
 	testPayload(t, pm, expected)
 }
+
+func TestValidAPS(t *testing.T) {
+	tests := []payload.APS{
+		{Alert: payload.Alert{Body: "You got your emails."}},
+		{Badge: badge.New(9)},
+		{Badge: badge.Clear},
+	}
+
+	for _, p := range tests {
+		if err := p.Validate(); err != nil {
+			t.Errorf("Expected no error, got %v.", err)
+		}
+	}
+}
+
+func TestInvalidAPS(t *testing.T) {
+	tests := []*payload.APS{
+		{Sound: "bingbong.aiff"},
+		{},
+		nil,
+	}
+
+	for _, p := range tests {
+		if err := p.Validate(); err != payload.ErrIncomplete {
+			t.Errorf("Expected err %v, got %v.", payload.ErrIncomplete, err)
+		}
+	}
+}

--- a/payload/browser.go
+++ b/payload/browser.go
@@ -19,7 +19,20 @@ type BrowserAlert struct {
 }
 
 // MarshalJSON allows you to json.Marshal(browser) directly.
-func (b Browser) MarshalJSON() ([]byte, error) {
-	aps := map[string]interface{}{"alert": b.Alert, "url-args": b.URLArgs}
+func (p Browser) MarshalJSON() ([]byte, error) {
+	aps := map[string]interface{}{"alert": p.Alert, "url-args": p.URLArgs}
 	return json.Marshal(map[string]interface{}{"aps": aps})
+}
+
+// Validate browser payload.
+func (p *Browser) Validate() error {
+	if p == nil {
+		return ErrIncomplete
+	}
+
+	// must have both a title and body. action and url-args are optional.
+	if len(p.Alert.Title) == 0 || len(p.Alert.Body) == 0 {
+		return ErrIncomplete
+	}
+	return nil
 }

--- a/payload/browser_test.go
+++ b/payload/browser_test.go
@@ -18,3 +18,31 @@ func TestBrowser(t *testing.T) {
 	expected := []byte(`{"aps":{"alert":{"title":"Flight A998 Now Boarding","body":"Boarding has begun for Flight A998.","action":"View"},"url-args":["boarding","A998"]}}`)
 	testPayload(t, p, expected)
 }
+
+func TestValidBrowser(t *testing.T) {
+	p := payload.Browser{
+		Alert: payload.BrowserAlert{
+			Title: "Flight A998 Now Boarding",
+			Body:  "Boarding has begun for Flight A998.",
+		},
+	}
+	if err := p.Validate(); err != nil {
+		t.Errorf("Expected no error, got %v.", err)
+	}
+}
+
+func TestInvalidBrowser(t *testing.T) {
+	tests := []*payload.Browser{
+		{
+			Alert: payload.BrowserAlert{Action: "View"},
+		},
+		{},
+		nil,
+	}
+
+	for _, p := range tests {
+		if err := p.Validate(); err != payload.ErrIncomplete {
+			t.Errorf("Expected err %v, got %v.", payload.ErrIncomplete, err)
+		}
+	}
+}

--- a/payload/mdm.go
+++ b/payload/mdm.go
@@ -4,3 +4,16 @@ package payload
 type MDM struct {
 	Token string `json:"mdm"`
 }
+
+// Validate MDM payload.
+func (p *MDM) Validate() error {
+	if p == nil {
+		return ErrIncomplete
+	}
+
+	// must have a token.
+	if len(p.Token) == 0 {
+		return ErrIncomplete
+	}
+	return nil
+}

--- a/payload/mdm_test.go
+++ b/payload/mdm_test.go
@@ -11,3 +11,23 @@ func TestMDM(t *testing.T) {
 	expected := []byte(`{"mdm":"00000000-1111-3333-4444-555555555555"}`)
 	testPayload(t, p, expected)
 }
+
+func TestValidMDM(t *testing.T) {
+	p := payload.MDM{"00000000-1111-3333-4444-555555555555"}
+	if err := p.Validate(); err != nil {
+		t.Errorf("Expected no error, got %v.", err)
+	}
+}
+
+func TestInvalidMDM(t *testing.T) {
+	tests := []*payload.MDM{
+		{},
+		nil,
+	}
+
+	for _, p := range tests {
+		if err := p.Validate(); err != payload.ErrIncomplete {
+			t.Errorf("Expected err %v, got %v.", payload.ErrIncomplete, err)
+		}
+	}
+}

--- a/payload/payload.go
+++ b/payload/payload.go
@@ -1,0 +1,9 @@
+// Package payload serializes a JSON payload to push.
+package payload
+
+import "errors"
+
+// validation errors
+var (
+	ErrIncomplete = errors.New("payload does not contain necessary fields")
+)

--- a/push/device_token.go
+++ b/push/device_token.go
@@ -1,0 +1,13 @@
+package push
+
+import "encoding/hex"
+
+// IsDeviceTokenValid checks if s is a hexadecimal token of the correct length.
+func IsDeviceTokenValid(s string) bool {
+	// TODO: In 2016, they may be growing up to 100 bytes (200 hexadecimal digits).
+	if len(s) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}

--- a/push/device_token_test.go
+++ b/push/device_token_test.go
@@ -1,0 +1,35 @@
+package push_test
+
+import (
+	"testing"
+
+	"github.com/RobotsAndPencils/buford/push"
+)
+
+func TestInvalidDeviceTokens(t *testing.T) {
+	tokens := []string{
+		"invalid-token",
+		"f00f",
+		"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl",
+		"50c4afb5 9197d2ba d1794be4 e63f2532 ee18c660 0ee655fa 38b0b380 94fd8847",
+		"<50c4afb5 9197d2ba d1794be4 e63f2532 ee18c660 0ee655fa 38b0b380 94fd8847>",
+	}
+
+	for _, token := range tokens {
+		if push.IsDeviceTokenValid(token) {
+			t.Errorf("Expected device token %q to be invalid.", token)
+		}
+	}
+}
+
+func TestValidDeviceToken(t *testing.T) {
+	tokens := []string{
+		"c2732227a1d8021cfaf781d71fb2f908c61f5861079a00954a5453f1d0281433",
+	}
+
+	for _, token := range tokens {
+		if !push.IsDeviceTokenValid(token) {
+			t.Errorf("Expected device token %q to be valid.", token)
+		}
+	}
+}


### PR DESCRIPTION
These validations are brought over from a closed source library. All of these validations are opt-in. They aren't performed automatically.

* APS notifications can contain just custom data without a badge or body, but Buford has no way of knowing if custom data will be added later.
* Passbook notifications are completely empty, but it doesn't really make sense to use APS or even serialize JSON when you can just use PushBytes with `{}`.
* Newsstand notifications are empty except for ContentAvailable. APS won't validate a payload like this right now. Newsstand isn't really a thing anymore, but maybe there are other cases where only ContentAvailable should be set? This could be another case where serialization can be skipped.
* ContentAvailable-only notifications must be used with the LowPriority header, but these are set in different packages so no attempt is made to validate this.
* Device tokens may get larger in the future. #13

These validations should probably be verified against the Apple documentation to make sure they are still the correct thing to do.

I haven't done anything to validate the push Headers yet, such as the UUID format for the ID or that the expiration is in the future.