### PR TITLE
Support for Category inside aps payload.

### DIFF
--- a/payload/aps.go
+++ b/payload/aps.go
@@ -78,6 +78,9 @@ func (a *APS) Map() map[string]interface{} {
 	if a.ContentAvailable {
 		aps["content-available"] = 1
 	}
+	if a.Category != "" {
+		aps["category"] = a.Category
+	}
 
 	// wrap in "aps" to form final payload
 	return map[string]interface{}{"aps": aps}


### PR DESCRIPTION
With this change we are able to send the category inside the aps payload.

```
p := payload.APS{
    Alert:    "Hello Push",
    Badge:    1,
    Sound:    "default",
    Category: "yesOrNo",
}
```