### PR TITLE
Revise error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ id, err := service.PushBytes(deviceToken, nil, b)
 
 Whether you use Push or PushBytes, the underlying HTTP/2 connection to APNS will be reused.
 
+#### Error responses
+
+Push and PushBytes may return an `error`. It could be an error the JSON encoding or HTTP request, or it could be a `push.Error` which contains the response from Apple. To access the Reason and Status code, you must convert the `error` to a `push.Error` as follows:
+
+```go
+if e, ok := err.(*push.Error); ok {
+	switch e.Reason {
+	case push.ErrBadDeviceToken:
+		// handle error
+	}
+}
+```
+
 ### Website Push
 
 Before you can send push notifications through Safari and the Notification Center, you must provide a push package, which is a signed zip file containing some JSON and icons.

--- a/push/service.go
+++ b/push/service.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// Apple host locations.
+// Apple host locations for configuring Service.
 const (
 	Development = "https://api.development.push.apple.com"
 	Production  = "https://api.push.apple.com"
@@ -34,7 +34,7 @@ type Headers struct {
 	// Apple will retry delivery until this time. The default behavior only tries once.
 	Expiration time.Time
 
-	// Allow Apple to group messages to together to reduce power consumption.
+	// Allow Apple to group messages together to reduce power consumption.
 	// By default messages are sent immediately.
 	LowPriority bool
 
@@ -42,110 +42,57 @@ type Headers struct {
 	Topic string
 }
 
-// Service error responses.
-var (
-	// These could be checked prior to sending the request to Apple.
-
-	ErrPayloadEmpty    = errors.New("the message payload was empty")
-	ErrPayloadTooLarge = errors.New("the message payload was too large")
-
-	// Device token errors.
-
-	ErrMissingDeviceToken = errors.New("device token was not specified")
-	ErrBadDeviceToken     = errors.New("bad device token")
-	ErrTooManyRequests    = errors.New("too many requests were made consecutively to the same device token")
-
-	// Header errors.
-
-	ErrBadMessageID      = errors.New("the ID header value is bad")
-	ErrBadExpirationDate = errors.New("the Expiration header value is bad")
-	ErrBadPriority       = errors.New("the apns-priority value is bad")
-	ErrBadTopic          = errors.New("the Topic header was invalid")
-
-	// Certificate and topic errors.
-
-	ErrBadCertificate            = errors.New("the certificate was bad")
-	ErrBadCertificateEnvironment = errors.New("certificate was for the wrong environment")
-	ErrForbidden                 = errors.New("there was an error with the certificate")
-
-	ErrMissingTopic           = errors.New("the Topic header of the request was not specified and was required")
-	ErrTopicDisallowed        = errors.New("pushing to this topic is not allowed")
-	ErrUnregistered           = errors.New("device token is inactive for the specified topic")
-	ErrDeviceTokenNotForTopic = errors.New("device token does not match the specified topic")
-
-	// These errors should never happen when using Push.
-
-	ErrDuplicateHeaders = errors.New("one or more headers were repeated")
-	ErrBadPath          = errors.New("the request contained a bad :path")
-	ErrMethodNotAllowed = errors.New("the specified :method was not POST")
-
-	// Fatal server errors.
-
-	ErrIdleTimeout         = errors.New("idle time out")
-	ErrShutdown            = errors.New("the server is shutting down")
-	ErrInternalServerError = errors.New("an internal server error occurred")
-	ErrServiceUnavailable  = errors.New("the service is unavailable")
-
-	// HTTP Status errors.
-
-	ErrBadRequest = errors.New("bad request")
-	ErrUnknown    = errors.New("unknown error")
-)
-
-// Error with a timestamp
+// Error responses from Apple
 type Error struct {
-	Err       error
+	Reason    error
 	Status    int // http StatusCode
 	Timestamp time.Time
 }
 
-func (e *Error) Error() string {
-	return e.Err.Error()
-}
+// Service error responses.
+var (
+	// These could be checked prior to sending the request to Apple.
 
-var errorReason = map[string]error{
-	"PayloadEmpty":              ErrPayloadEmpty,
-	"PayloadTooLarge":           ErrPayloadTooLarge,
-	"BadTopic":                  ErrBadTopic,
-	"TopicDisallowed":           ErrTopicDisallowed,
-	"BadMessageId":              ErrBadMessageID,
-	"BadExpirationDate":         ErrBadExpirationDate,
-	"BadPriority":               ErrBadPriority,
-	"MissingDeviceToken":        ErrMissingDeviceToken,
-	"BadDeviceToken":            ErrBadDeviceToken,
-	"DeviceTokenNotForTopic":    ErrDeviceTokenNotForTopic,
-	"Unregistered":              ErrUnregistered,
-	"DuplicateHeaders":          ErrDuplicateHeaders,
-	"BadCertificateEnvironment": ErrBadCertificateEnvironment,
-	"BadCertificate":            ErrBadCertificate,
-	"Forbidden":                 ErrForbidden,
-	"BadPath":                   ErrBadPath,
-	"MethodNotAllowed":          ErrMethodNotAllowed,
-	"TooManyRequests":           ErrTooManyRequests,
-	"IdleTimeout":               ErrIdleTimeout,
-	"Shutdown":                  ErrShutdown,
-	"InternalServerError":       ErrInternalServerError,
-	"ServiceUnavailable":        ErrServiceUnavailable,
-	"MissingTopic":              ErrMissingTopic,
-}
+	ErrPayloadEmpty    = errors.New("PayloadEmpty")
+	ErrPayloadTooLarge = errors.New("PayloadTooLarge")
 
-var errorStatus = map[int]error{
-	http.StatusBadRequest:            ErrBadRequest,
-	http.StatusForbidden:             ErrForbidden,
-	http.StatusMethodNotAllowed:      ErrMethodNotAllowed,
-	http.StatusGone:                  ErrUnregistered,
-	http.StatusRequestEntityTooLarge: ErrPayloadTooLarge,
-	http.StatusTooManyRequests:       ErrTooManyRequests,
-	http.StatusInternalServerError:   ErrInternalServerError,
-	http.StatusServiceUnavailable:    ErrServiceUnavailable,
-}
+	// Device token errors.
 
-type response struct {
-	// Reason for failure
-	Reason string `json:"reason"`
-	// Timestamp for 410 StatusGone (ErrUnregistered)
-	Timestamp int64 `json:"timestamp"`
-}
+	ErrMissingDeviceToken = errors.New("MissingDeviceToken")
+	ErrBadDeviceToken     = errors.New("BadDeviceToken")
+	ErrTooManyRequests    = errors.New("TooManyRequests")
+
+	// Header errors.
+
+	ErrBadMessageID      = errors.New("BadMessageID")
+	ErrBadExpirationDate = errors.New("BadExpirationDate")
+	ErrBadPriority       = errors.New("BadPriority")
+	ErrBadTopic          = errors.New("BadTopic")
+
+	// Certificate and topic errors.
+
+	ErrBadCertificate            = errors.New("BadCertificate")
+	ErrBadCertificateEnvironment = errors.New("BadCertificateEnvironment")
+	ErrForbidden                 = errors.New("Forbidden")
+
+	ErrMissingTopic           = errors.New("MissingTopic")
+	ErrTopicDisallowed        = errors.New("TopicDisallowed")
+	ErrUnregistered           = errors.New("Unregistered")
+	ErrDeviceTokenNotForTopic = errors.New("DeviceTokenNotForTopic")
+
+	// These errors should never happen when using Push.
+
+	ErrDuplicateHeaders = errors.New("DuplicateHeaders")
+	ErrBadPath          = errors.New("BadPath")
+	ErrMethodNotAllowed = errors.New("MethodNotAllowed")
+
+	// Fatal server errors.
+
+	ErrIdleTimeout         = errors.New("IdleTimeout")
+	ErrShutdown            = errors.New("Shutdown")
+	ErrInternalServerError = errors.New("InternalServerError")
+	ErrServiceUnavailable  = errors.New("ServiceUnavailable")
+)
 
 // Push notification to APN service after performing serialization.
 func (s *Service) Push(deviceToken string, headers *Headers, payload interface{}) (string, error) {
@@ -177,29 +124,25 @@ func (s *Service) PushBytes(deviceToken string, headers *Headers, payload []byte
 		return resp.Header.Get("apns-id"), nil
 	}
 
-	var response response
+	var response struct {
+		// Reason for failure
+		Reason string `json:"reason"`
+		// Timestamp for 410 StatusGone (ErrUnregistered)
+		Timestamp int64 `json:"timestamp"`
+	}
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return "", err
 	}
 
-	e, ok := errorReason[response.Reason]
-	if !ok {
-		// fallback to HTTP status codes if reason not found in JSON
-		e, ok = errorStatus[resp.StatusCode]
-		if !ok {
-			e = ErrUnknown
-		}
-	}
-
 	es := &Error{
-		Err:    e,
+		Reason: mapErrorReason(response.Reason),
 		Status: resp.StatusCode,
 	}
 
 	if response.Timestamp != 0 {
 		// the response.Timestamp is Milliseconds, but time.Unix() requires seconds
-		es.Timestamp = time.Unix(response.Timestamp/1000, 0)
+		es.Timestamp = time.Unix(response.Timestamp/1000, 0).UTC()
 	}
 
 	return "", es
@@ -226,5 +169,115 @@ func (h *Headers) set(reqHeader http.Header) {
 
 	if h.Topic != "" {
 		reqHeader.Set("apns-topic", h.Topic)
+	}
+}
+
+// mapErrorReason converts Apple error responses into exported Err variables
+// for comparisons.
+func mapErrorReason(reason string) error {
+	var e error
+	switch reason {
+	case "PayloadEmpty":
+		e = ErrPayloadEmpty
+	case "PayloadTooLarge":
+		e = ErrPayloadTooLarge
+	case "BadTopic":
+		e = ErrBadTopic
+	case "TopicDisallowed":
+		e = ErrTopicDisallowed
+	case "BadMessageId":
+		e = ErrBadMessageID
+	case "BadExpirationDate":
+		e = ErrBadExpirationDate
+	case "BadPriority":
+		e = ErrBadPriority
+	case "MissingDeviceToken":
+		e = ErrMissingDeviceToken
+	case "BadDeviceToken":
+		e = ErrBadDeviceToken
+	case "DeviceTokenNotForTopic":
+		e = ErrDeviceTokenNotForTopic
+	case "Unregistered":
+		e = ErrUnregistered
+	case "DuplicateHeaders":
+		e = ErrDuplicateHeaders
+	case "BadCertificateEnvironment":
+		e = ErrBadCertificateEnvironment
+	case "BadCertificate":
+		e = ErrBadCertificate
+	case "Forbidden":
+		e = ErrForbidden
+	case "BadPath":
+		e = ErrBadPath
+	case "MethodNotAllowed":
+		e = ErrMethodNotAllowed
+	case "TooManyRequests":
+		e = ErrTooManyRequests
+	case "IdleTimeout":
+		e = ErrIdleTimeout
+	case "Shutdown":
+		e = ErrShutdown
+	case "InternalServerError":
+		e = ErrInternalServerError
+	case "ServiceUnavailable":
+		e = ErrServiceUnavailable
+	case "MissingTopic":
+		e = ErrMissingTopic
+	default:
+		e = errors.New(reason)
+	}
+	return e
+}
+
+func (e *Error) Error() string {
+	switch e.Reason {
+	case ErrPayloadEmpty:
+		return "the message payload was empty"
+	case ErrPayloadTooLarge:
+		return "the message payload was too large"
+	case ErrMissingDeviceToken:
+		return "device token was not specified"
+	case ErrBadDeviceToken:
+		return "bad device token"
+	case ErrTooManyRequests:
+		return "too many requests were made consecutively to the same device token"
+	case ErrBadMessageID:
+		return "the ID header value is bad"
+	case ErrBadExpirationDate:
+		return "the Expiration header value is bad"
+	case ErrBadPriority:
+		return "the apns-priority value is bad"
+	case ErrBadTopic:
+		return "the Topic header was invalid"
+	case ErrBadCertificate:
+		return "the certificate was bad"
+	case ErrBadCertificateEnvironment:
+		return "certificate was for the wrong environment"
+	case ErrForbidden:
+		return "there was an error with the certificate"
+	case ErrMissingTopic:
+		return "the Topic header of the request was not specified and was required"
+	case ErrTopicDisallowed:
+		return "pushing to this topic is not allowed"
+	case ErrUnregistered:
+		return fmt.Sprintf("device token is inactive for the specified topic (last invalid at %v)", e.Timestamp)
+	case ErrDeviceTokenNotForTopic:
+		return "device token does not match the specified topic"
+	case ErrDuplicateHeaders:
+		return "one or more headers were repeated"
+	case ErrBadPath:
+		return "the request contained a bad :path"
+	case ErrMethodNotAllowed:
+		return "the specified :method was not POST"
+	case ErrIdleTimeout:
+		return "idle time out"
+	case ErrShutdown:
+		return "the server is shutting down"
+	case ErrInternalServerError:
+		return "an internal server error occurred"
+	case ErrServiceUnavailable:
+		return "the service is unavailable"
+	default:
+		return fmt.Sprintf("unknown error: %v", e.Reason.Error())
 	}
 }

--- a/push/service_test.go
+++ b/push/service_test.go
@@ -75,8 +75,13 @@ func TestBadPriorityPush(t *testing.T) {
 		t.Fatalf("Expected push error, got %v.", err)
 	}
 
-	if e.Err != push.ErrBadPriority {
+	if e.Reason != push.ErrBadPriority {
 		t.Errorf("Expected error %v, got %v.", push.ErrBadPriority, err)
+	}
+
+	const expectedMessage = "the apns-priority value is bad"
+	if e.Error() != expectedMessage {
+		t.Errorf("Expected error message %q, got %q.", expectedMessage, e.Error())
 	}
 
 	if e.Status != http.StatusBadRequest {
@@ -112,15 +117,20 @@ func TestTimestampError(t *testing.T) {
 		t.Fatalf("Expected push error, got %v.", err)
 	}
 
-	if e.Err != push.ErrUnregistered {
-		t.Errorf("Expected error %v, got %v.", push.ErrUnregistered, err)
+	if e.Reason != push.ErrUnregistered {
+		t.Errorf("Expected error reason %v, got %v.", push.ErrUnregistered, err)
+	}
+
+	const expectedMessage = "device token is inactive for the specified topic (last invalid at 2370-01-01 00:00:00 +0000 UTC)"
+	if e.Error() != expectedMessage {
+		t.Errorf("Expected error message %q, got %q.", expectedMessage, e.Error())
 	}
 
 	if e.Status != http.StatusGone {
 		t.Errorf("Expected status %v, got %v.", http.StatusGone, e.Status)
 	}
 
-	expected := time.Unix(12622780800, 0)
+	expected := time.Unix(12622780800, 0).UTC()
 	if e.Timestamp != expected {
 		t.Errorf("Expected timestamp %v, got %v.", expected, e.Timestamp)
 	}


### PR DESCRIPTION
* [x] add Status code to Error struct and always return struct for responses from Apple
* [x] push.Error.Reason (renamed) matches the reason from Apple, but can still be compared to exported Err variables
* [x] use switch statements instead of maps for efficiency (I think)

closes #42 

Any feedback on this @froodian (or anyone else)?