### PR TITLE
initial support for Token Authentication (JWT)

### DIFF
--- a/push/errors.go
+++ b/push/errors.go
@@ -30,6 +30,10 @@ var (
 	ErrBadPriority       = errors.New("BadPriority")
 	ErrBadTopic          = errors.New("BadTopic")
 
+	// Token authentication errors.
+	ErrInvalidProviderToken = errors.New("InvalidProviderToken")
+	ErrExpiredProviderToken = errors.New("ExpiredProviderToken")
+
 	// Certificate and topic errors.
 	ErrBadCertificate            = errors.New("BadCertificate")
 	ErrBadCertificateEnvironment = errors.New("BadCertificateEnvironment")
@@ -80,6 +84,10 @@ func mapErrorReason(reason string) error {
 		e = ErrUnregistered
 	case "DuplicateHeaders":
 		e = ErrDuplicateHeaders
+	case "InvalidProviderToken":
+		e = ErrInvalidProviderToken
+	case "ExpiredProviderToken":
+		e = ErrExpiredProviderToken
 	case "BadCertificateEnvironment":
 		e = ErrBadCertificateEnvironment
 	case "BadCertificate":
@@ -128,6 +136,10 @@ func (e *Error) Error() string {
 		return "the apns-priority value is bad"
 	case ErrBadTopic:
 		return "the Topic header was invalid"
+	case ErrInvalidProviderToken:
+		return "JWT authentication token is invalid"
+	case ErrExpiredProviderToken:
+		return "JWT authentication token expired"
 	case ErrBadCertificate:
 		return "the certificate was bad"
 	case ErrBadCertificateEnvironment:

--- a/push/header.go
+++ b/push/header.go
@@ -25,6 +25,9 @@ type Headers struct {
 
 	// Topic for certificates with multiple topics.
 	Topic string
+
+	// Authorization for Token Authentication (JWT)
+	Authorization string
 }
 
 // set headers for an HTTP request
@@ -52,6 +55,10 @@ func (h *Headers) set(reqHeader http.Header) {
 
 	if h.Topic != "" {
 		reqHeader.Set("apns-topic", h.Topic)
+	}
+
+	if h.Authorization != "" {
+		reqHeader.Set("authorization", "bearer "+h.Authorization)
 	}
 
 }

--- a/push/header_test.go
+++ b/push/header_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestHeaders(t *testing.T) {
 	headers := Headers{
-		ID:          "uuid",
-		CollapseID:  "game1.score.identifier",
-		Expiration:  time.Unix(12622780800, 0),
-		LowPriority: true,
-		Topic:       "bundle-id",
+		ID:            "uuid",
+		CollapseID:    "game1.score.identifier",
+		Expiration:    time.Unix(12622780800, 0),
+		LowPriority:   true,
+		Topic:         "bundle-id",
+		Authorization: "eyJhbGciOiJFUzI1N",
 	}
 
 	reqHeader := http.Header{}
@@ -23,6 +24,7 @@ func TestHeaders(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "12622780800")
 	testHeader(t, reqHeader, "apns-priority", "5")
 	testHeader(t, reqHeader, "apns-topic", "bundle-id")
+	testHeader(t, reqHeader, "authorization", "bearer eyJhbGciOiJFUzI1N")
 }
 
 func TestNilHeader(t *testing.T) {
@@ -35,6 +37,7 @@ func TestNilHeader(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "")
 	testHeader(t, reqHeader, "apns-priority", "")
 	testHeader(t, reqHeader, "apns-topic", "")
+	testHeader(t, reqHeader, "authorization", "")
 }
 
 func TestEmptyHeaders(t *testing.T) {
@@ -47,6 +50,7 @@ func TestEmptyHeaders(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "")
 	testHeader(t, reqHeader, "apns-priority", "")
 	testHeader(t, reqHeader, "apns-topic", "")
+	testHeader(t, reqHeader, "authorization", "")
 }
 
 func testHeader(t *testing.T, reqHeader http.Header, key, expected string) {


### PR DESCRIPTION
Just a start to enable use with Token Authentication, based on these slides https://developer.apple.com/videos/play/wwdc2016/724/

ref #63

```go
service := push.NewService(http.DefaultClient, host)
// ...
id, err := service.Push(deviceToken, &push.Headers{Authorization: "eyJhbGciOiJFUzI1N"}, b)
```

Unfortunately this isn't working quite yet. I'm not even getting a **InvalidProviderToken** error from Apple.

```
❯ GODEBUG=http2debug=1 go run main.go -d devicetoken                      
2016/06/15 15:01:04 http2: Transport failed to get client conn for api.development.push.apple.com:443: http2: no cached connection was available
2016/06/15 15:01:05 http2: Transport creating client conn to 17.172.238.203:443
2016/06/15 15:01:05 Unhandled Setting: [HEADER_TABLE_SIZE = 4096]
2016/06/15 15:01:05 Unhandled Setting: [MAX_HEADER_LIST_SIZE = 8000]
2016/06/15 15:01:05 http2: Transport failed to get client conn for api.development.push.apple.com:443: http2: no cached connection was available
Post https://api.development.push.apple.com/3/device/devicetoken: http2: no cached connection was available
exit status 1
```