### PR TITLE
Support for grouping notifications with thread-id

### DIFF
--- a/payload/aps.go
+++ b/payload/aps.go
@@ -29,6 +29,9 @@ type APS struct {
 
 	// Mutable is used for Service Extensions introduced in iOS 10.
 	MutableContent bool
+
+	// Thread identifier to create notification groups in iOS 12 or newer.
+	ThreadID string
 }
 
 // Alert dictionary.
@@ -92,6 +95,9 @@ func (a *APS) Map() map[string]interface{} {
 	}
 	if a.MutableContent {
 		aps["mutable-content"] = 1
+	}
+	if a.ThreadID != "" {
+		aps["thread-id"] = a.ThreadID
 	}
 
 	// wrap in "aps" to form the final payload

--- a/payload/aps_test.go
+++ b/payload/aps_test.go
@@ -91,6 +91,13 @@ func TestPayload(t *testing.T) {
 			},
 			[]byte(`{"aps":{"alert":"Change is coming","mutable-content":1}}`),
 		},
+		{
+			payload.APS{
+					Alert:          payload.Alert{Body: "Grouped notification"},
+					ThreadID: "thread-id-1",
+			},
+			[]byte(`{"aps":{"alert":"Grouped notification","thread-id":"thread-id-1"}}`),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
iOS 12 or newer versions has the feature of grouping notifications.
It devides each groups with `thread-id` , so added support for that parameter and changes to `apns_test.go`

Ref: https://developer.apple.com/videos/play/wwdc2018/711/