### PR TITLE
apns-push-type header is required on iOS 13 and later

### DIFF
--- a/push/errors.go
+++ b/push/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrBadExpirationDate = errors.New("BadExpirationDate")
 	ErrBadPriority       = errors.New("BadPriority")
 	ErrBadTopic          = errors.New("BadTopic")
+	ErrInvalidPushType   = errors.New("InvalidPushType")
 
 	// Certificate and topic errors.
 	ErrBadCertificate            = errors.New("BadCertificate")
@@ -102,6 +103,8 @@ func mapErrorReason(reason string) error {
 		e = ErrServiceUnavailable
 	case "MissingTopic":
 		e = ErrMissingTopic
+	case "InvalidPushType":
+		e = ErrInvalidPushType
 	default:
 		e = errors.New(reason)
 	}
@@ -136,6 +139,8 @@ func (e *Error) Error() string {
 		return "there was an error with the certificate"
 	case ErrMissingTopic:
 		return "the Topic header of the request was not specified and was required"
+	case ErrInvalidPushType:
+		return "the apns-push-type value is invalid"
 	case ErrTopicDisallowed:
 		return "pushing to this topic is not allowed"
 	case ErrUnregistered:

--- a/push/header.go
+++ b/push/header.go
@@ -25,7 +25,16 @@ type Headers struct {
 
 	// Topic for certificates with multiple topics.
 	Topic string
+
+	PushType PushType
 }
+
+type PushType string
+
+const (
+	PushTypeAlert      PushType = "alert"
+	PushTypeBackground PushType = "background"
+)
 
 // set headers for an HTTP request
 func (h *Headers) set(reqHeader http.Header) {
@@ -54,4 +63,7 @@ func (h *Headers) set(reqHeader http.Header) {
 		reqHeader.Set("apns-topic", h.Topic)
 	}
 
+	if h.PushType != "" {
+		reqHeader.Set("apns-push-type", string(h.PushType))
+	}
 }

--- a/push/header_test.go
+++ b/push/header_test.go
@@ -13,6 +13,7 @@ func TestHeaders(t *testing.T) {
 		Expiration:  time.Unix(12622780800, 0),
 		LowPriority: true,
 		Topic:       "bundle-id",
+		PushType:    PushTypeAlert,
 	}
 
 	reqHeader := http.Header{}
@@ -23,6 +24,7 @@ func TestHeaders(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "12622780800")
 	testHeader(t, reqHeader, "apns-priority", "5")
 	testHeader(t, reqHeader, "apns-topic", "bundle-id")
+	testHeader(t, reqHeader, "apns-push-type", "alert")
 }
 
 func TestNilHeader(t *testing.T) {
@@ -35,6 +37,7 @@ func TestNilHeader(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "")
 	testHeader(t, reqHeader, "apns-priority", "")
 	testHeader(t, reqHeader, "apns-topic", "")
+	testHeader(t, reqHeader, "apns-push-type", "")
 }
 
 func TestEmptyHeaders(t *testing.T) {
@@ -47,6 +50,7 @@ func TestEmptyHeaders(t *testing.T) {
 	testHeader(t, reqHeader, "apns-expiration", "")
 	testHeader(t, reqHeader, "apns-priority", "")
 	testHeader(t, reqHeader, "apns-topic", "")
+	testHeader(t, reqHeader, "apns-push-type", "")
 }
 
 func testHeader(t *testing.T, reqHeader http.Header, key, expected string) {


### PR DESCRIPTION
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947610