### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	github.com/aai/gocrypto v0.0.0-20160205191751-93df0c47f8b8
 	github.com/gorilla/mux v1.7.3
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
 )


### PR DESCRIPTION
Updated golang.org/x/crypto mod to resolve CVE-2019-11840 (NVD)